### PR TITLE
Speed up automatic strategy unit test and add guards around memory usage

### DIFF
--- a/src/main/java/org/x42bn6/nopassword/hashingstrategies/Argon2HashingStrategy.java
+++ b/src/main/java/org/x42bn6/nopassword/hashingstrategies/Argon2HashingStrategy.java
@@ -104,7 +104,7 @@ public class Argon2HashingStrategy implements HashingStrategy {
         Argon2Parameters params = new Argon2Parameters.Builder(type)
                 .withSalt(salt)
                 .withParallelism(parallelism)
-                .withMemoryAsKB(memoryCost)
+                .withMemoryAsKB(Long.valueOf(memoryCost).intValue())
                 .withIterations(timeCost)
                 .build();
         Argon2BytesGenerator generator = new Argon2BytesGenerator();
@@ -135,12 +135,16 @@ public class Argon2HashingStrategy implements HashingStrategy {
 
         /**
          * The memory cost, in kB (default: 256 MB).
+         * <p>
+         * Due to library restrictions (usage of {@code int} rather than {@code long}), memory cost is capped at 2 ^ 32
+         * - 1 kB.
          *
          * @param memoryCost The memory cost to use
          * @return The builder
          */
-        public Builder memoryCost(int memoryCost) {
-            this.memoryCost = memoryCost;
+        public Builder memoryCost(long memoryCost) {
+            memoryCost = Math.min(memoryCost, Integer.MAX_VALUE);
+            this.memoryCost = Long.valueOf(memoryCost).intValue();
             return this;
         }
 

--- a/src/main/java/org/x42bn6/nopassword/hashingstrategies/AutomaticArgon2HashingStrategy.java
+++ b/src/main/java/org/x42bn6/nopassword/hashingstrategies/AutomaticArgon2HashingStrategy.java
@@ -32,6 +32,9 @@ import java.security.SecureRandom;
 public class AutomaticArgon2HashingStrategy {
     private static final SecureRandom SECURE_RANDOM;
     private static final int ITERATIONS_FOR_AVERAGING = 10;
+    private static final int SALT_LENGTH = 16;
+    private static final int HASH_LENGTH = 32;
+    public static final int ONE_SECOND_IN_MILLISECONDS = 1000;
 
     static {
         final String algorithm = "SHA1PRNG";
@@ -42,19 +45,49 @@ public class AutomaticArgon2HashingStrategy {
         }
     }
 
+    /**
+     * Determines the optimal strategy through hardware heuristics.
+     *
+     * @return An Argon2 strategy with optimal parameters
+     */
     public static Argon2HashingStrategy determineOptimalStrategy() {
+        return determineOptimalStrategy(
+                Runtime.getRuntime().availableProcessors(),
+                Runtime.getRuntime().freeMemory(),
+                ONE_SECOND_IN_MILLISECONDS
+        );
+    }
+
+    /**
+     * Determines the optimal strategy through hardware heuristics.
+     *
+     * @param processorCount The processor count (default: {@link Runtime#availableProcessors()})
+     * @param freeMemory     The free memory in bytes (default: {@link Runtime#freeMemory()})
+     * @param desiredTime    The desired hashing time, in milliseconds (default: 1000)
+     * @return An Argon2 strategy with optimal parameters
+     */
+    public static Argon2HashingStrategy determineOptimalStrategy(int processorCount, long freeMemory, int desiredTime) {
+        long freeMemoryBytes = freeMemory / 1024;
         long timeTaken = Long.MIN_VALUE;
         int iterations = 1;
 
+        Argon2HashingStrategy previousStrategy = new Argon2HashingStrategy.Builder()
+                .parallelism(processorCount)
+                .memoryCost(freeMemoryBytes)
+                .timeCost(iterations)
+                .saltLength(SALT_LENGTH)
+                .hashLength(HASH_LENGTH)
+                .build();
         Argon2HashingStrategy candidateStrategy = null;
-        // 1 second
-        while (timeTaken < 1000) {
+        boolean currentStrategyWithinTarget = true;
+        while (timeTaken < desiredTime && currentStrategyWithinTarget) {
+            previousStrategy = candidateStrategy;
             candidateStrategy = new Argon2HashingStrategy.Builder()
-                    .parallelism(Runtime.getRuntime().availableProcessors())
-                    .memoryCost((int) (Runtime.getRuntime().freeMemory() / 1024))
+                    .parallelism(processorCount)
+                    .memoryCost(freeMemoryBytes)
                     .timeCost(iterations++)
-                    .saltLength(16)
-                    .hashLength(32)
+                    .saltLength(SALT_LENGTH)
+                    .hashLength(HASH_LENGTH)
                     .build();
 
             long totalTime = 0L;
@@ -64,11 +97,19 @@ public class AutomaticArgon2HashingStrategy {
                 long start = System.currentTimeMillis();
                 candidateStrategy.generateHashWithNewSalt(password);
                 long end = System.currentTimeMillis();
-                totalTime += end - start;
+
+                // If time is far beyond the desired time, break out immediately
+                final long elapsed = end - start;
+                if (elapsed > desiredTime * 2) {
+                    currentStrategyWithinTarget = false;
+                    break;
+                }
+
+                totalTime += elapsed;
             }
             timeTaken = totalTime / ITERATIONS_FOR_AVERAGING;
         }
 
-        return candidateStrategy;
+        return previousStrategy;
     }
 }

--- a/src/test/java/org/x42bn6/nopassword/hashingstrategies/AutomaticArgon2HashingStrategyTest.java
+++ b/src/test/java/org/x42bn6/nopassword/hashingstrategies/AutomaticArgon2HashingStrategyTest.java
@@ -6,6 +6,7 @@ class AutomaticArgon2HashingStrategyTest {
 
     @Test
     void determineOptimalStrategy() {
-        AutomaticArgon2HashingStrategy.determineOptimalStrategy();
+        // 1 core, 256 MB RAM, 1ms
+        AutomaticArgon2HashingStrategy.determineOptimalStrategy(1, (1 << 20) * 256, 1);
     }
 }


### PR DESCRIPTION
…6 MB parameters to make sure the unit test doesn't take ages to run

- Add "early jump out" in strategy determination if any iteration is twice the desired time.  Might need a smarter strategy for warm-up time in the future (first iteration will always be slow)
- Add test to check that memory use (in kB) can be converted into an int (library restriction).  This means that if a system has more than 2 ^ 32 - 1 kB of free memory, it is capped to that value