### PR TITLE
Initial "alphabet" stub (allow for symbols and uppercase to be output where required)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-migrationsupport</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>

--- a/src/main/java/org/x42bn6/nopassword/CredentialMetadata.java
+++ b/src/main/java/org/x42bn6/nopassword/CredentialMetadata.java
@@ -25,9 +25,13 @@ public class CredentialMetadata {
         this(new byte[0], null);
     }
 
-    public CredentialMetadata(byte[] salt, HashingStrategy hashingStrategy) {
+    public CredentialMetadata(byte[] salt, Service service) {
         this.salt = salt;
-        this.hashingStrategy = hashingStrategy;
+        if (null != service) {
+            this.hashingStrategy = service.getHashingStrategy();
+        } else {
+            this.hashingStrategy = null;
+        }
     }
 
     public byte[] getSalt() {

--- a/src/main/java/org/x42bn6/nopassword/OutputEncoding.java
+++ b/src/main/java/org/x42bn6/nopassword/OutputEncoding.java
@@ -1,0 +1,323 @@
+package org.x42bn6.nopassword;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import org.x42bn6.nopassword.utilities.ByteArrayOperations;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static org.x42bn6.nopassword.utilities.ByteArrayOperations.checkIn;
+import static org.x42bn6.nopassword.utilities.ByteArrayOperations.clear;
+
+/**
+ * {@code OutputEncoding} represents the set of symbols that a {@link Service}'s password can span.
+ * <p>
+ * By default, the password follows lowercase Base64 - all lowercase letters (without diacritics) and numbers - but some
+ * services may have stronger requirements.  No Password supports the following:
+ *
+ * <ul>
+ *     <li>Lowercase letters (default)</li>
+ *     <li>Numbers (default)</li>
+ *     <li>Uppercase letters</li>
+ *     <li>Symbols</li>
+ * </ul>
+ * <p>
+ * No Password will attempt to generate a password that satisfies all the requirements.  It does this by replacing
+ * the entire Base64 alphabet with random characters from each of the required sets above, and applying this
+ * bijection on top of the generated password, saving this bijection.
+ * <p>
+ * For symbols, No Password will pull a number of random symbols (the user can specify the number required).
+ */
+@JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE)
+public class OutputEncoding {
+    private static final byte[] BASE64_INDEX_TABLE = {
+            (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F', (byte) 'G',
+            (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N',
+            (byte) 'O', (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U',
+            (byte) 'V', (byte) 'W', (byte) 'X', (byte) 'Y', (byte) 'Z',
+            (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e', (byte) 'f', (byte) 'g',
+            (byte) 'h', (byte) 'i', (byte) 'j', (byte) 'k', (byte) 'l', (byte) 'm', (byte) 'n',
+            (byte) 'o', (byte) 'p', (byte) 'q', (byte) 'r', (byte) 's', (byte) 't', (byte) 'u',
+            (byte) 'v', (byte) 'w', (byte) 'x', (byte) 'y', (byte) 'z',
+            (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6',
+            (byte) '7', (byte) '8', (byte) '9',
+            (byte) '+', (byte) '/'
+    };
+
+    private static final byte[] UPPERCASE = {
+            (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F', (byte) 'G',
+            (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N',
+            (byte) 'O', (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U',
+            (byte) 'V', (byte) 'W', (byte) 'X', (byte) 'Y', (byte) 'Z'
+    };
+
+    private static final byte[] LOWERCASE = {
+            (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e', (byte) 'f', (byte) 'g',
+            (byte) 'h', (byte) 'i', (byte) 'j', (byte) 'k', (byte) 'l', (byte) 'm', (byte) 'n',
+            (byte) 'o', (byte) 'p', (byte) 'q', (byte) 'r', (byte) 's', (byte) 't', (byte) 'u',
+            (byte) 'v', (byte) 'w', (byte) 'x', (byte) 'y', (byte) 'z'
+    };
+
+    private static final byte[] NUMBERS = {
+            (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6',
+            (byte) '7', (byte) '8', (byte) '9'
+    };
+
+    private static final byte[] SYMBOLS = {
+            (byte) '!', (byte) '"', (byte) '#', (byte) '$', (byte) '%', (byte) '&', (byte) '\'',
+            (byte) '(', (byte) ')', (byte) '*', (byte) '+', (byte) ',', (byte) '-', (byte) '.',
+            (byte) '/'
+    };
+
+    /**
+     * Denotes the minimum number of uppercase letters required (default: 0).
+     */
+    private final int uppercaseCount;
+
+    /**
+     * Denotes the minimum number of lowercase letters required (default: 1).
+     */
+    private final int lowercaseCount;
+
+    /**
+     * Denotes the minimum number of numbers required (default: 1).
+     */
+    private final int numberCount;
+
+    /**
+     * Denotes the minimum number of symbols required (default: 0).
+     */
+    private final int symbolCount;
+
+    /**
+     * Denotes the bijection between Base64 and output alphabet randomisation.  This array is of length 64 (matching
+     * Base64).  The bijection is defined such that index <pre>i</pre> of {@link #SYMBOLS} maps to index
+     * <pre>i</pre> of this array.
+     */
+    private final byte[] mapping;
+
+    public OutputEncoding(Builder builder) {
+        this.uppercaseCount = builder.uppercaseCount;
+        this.lowercaseCount = builder.lowercaseCount;
+        this.numberCount = builder.numberCount;
+        this.symbolCount = builder.symbolCount;
+        this.mapping = builder.mapping;
+    }
+
+    public int getUppercaseCount() {
+        return uppercaseCount;
+    }
+
+    public int getLowercaseCount() {
+        return lowercaseCount;
+    }
+
+    public int getNumberCount() {
+        return numberCount;
+    }
+
+    public int getSymbolCount() {
+        return symbolCount;
+    }
+
+    public byte[] getMapping() {
+        return mapping;
+    }
+
+    /**
+     * Remaps a password based on the input Base64-encoded password.
+     * <p>
+     * This method avoids using collection-based classes to avoid putting password-based information on the heap.
+     *
+     * @param password The input password
+     * @return The remapped password
+     */
+    public byte[] remap(byte[] password) {
+        byte[] uniques = new byte[0];
+        boolean[] required = new boolean[0];
+        int[] outputCounts = new int[0];
+        byte[] shuffledUniques = new byte[0];
+        byte[] unpicked = new byte[0];
+        byte[] unmapped = new byte[0];
+        byte[] finalAlphabet = new byte[0];
+        try {
+            // Get all unique characters
+            uniques = new byte[0];
+            for (byte b : password) {
+                if (checkIn(b, uniques)) {
+                    continue;
+                }
+
+                // Resize array
+                uniques = Arrays.copyOf(uniques, uniques.length + 1);
+                uniques[uniques.length - 1] = b;
+            }
+
+            // How many of each set do we need?
+            int setCount =
+                    (uppercaseCount > 0 ? 1 : 0) +
+                            (lowercaseCount > 0 ? 1 : 0) +
+                            (numberCount > 0 ? 1 : 0) +
+                            (symbolCount > 0 ? 1 : 0);
+
+            // We may have leftovers after dividing.
+            // Distribute leftovers - prefer symbol -> number -> uppercase
+            int perSet = uniques.length / setCount;
+            int remainder = uniques.length - perSet * setCount;
+            required = new boolean[]{symbolCount > 0, numberCount > 0, uppercaseCount > 0, lowercaseCount > 0};
+            outputCounts = new int[]{perSet, perSet, perSet, perSet};
+            int remainderIndex = 0;
+            while (remainder > 0) {
+                if (required[remainderIndex]) {
+                    outputCounts[remainderIndex]++;
+                    remainderIndex++;
+                    remainder--;
+                }
+            }
+
+            // Pick the required number of unique characters per set
+            final SecureRandom secureRandom = PRNG.newInstance();
+            shuffledUniques = new byte[uniques.length];
+            int shuffledUniquesIndex = 0;
+            for (int i = 0; i < outputCounts.length; i++) {
+                Type type;
+                switch (i) {
+                    case 0:
+                        type = Type.SYMBOL;
+                        break;
+                    case 1:
+                        type = Type.NUMBER;
+                        break;
+                    case 2:
+                        type = Type.UPPERCASE;
+                        break;
+                    case 3:
+                        type = Type.LOWERCASE;
+                        break;
+                    default:
+                        throw new IllegalStateException("Unable to map index [" + i + "] to type");
+                }
+                final int targetRandomCharacters = outputCounts[i];
+                final byte[] randomBytes = type.randomN(targetRandomCharacters, secureRandom);
+                for (byte randomByte : randomBytes) {
+                    shuffledUniques[shuffledUniquesIndex++] = randomByte;
+                }
+            }
+
+            // Now we need to map the other, unmapped characters, and generate the full bijection
+            // First, get the full alphabet (i.e. if symbols are required, make sure all symbols are included -
+            // repeat for all types)
+            // Second, get the unpicked characters from the input
+            // Third, get the unmapped characters from the previous step
+            // Fourth, create a bijection from the remainder
+            int count = 0;
+            for (int i = 0; i < required.length; i++) {
+                if (required[i]) {
+                    count += Type.values()[i].alphabet.length;
+                }
+            }
+
+            finalAlphabet = new byte[count];
+            int fI = 0;
+            for (int i = 0; i < required.length; i++) {
+                if (!required[i]) {
+                    continue;
+                }
+
+                final byte[] targetAlphabet = Type.values()[i].alphabet;
+                for (byte b : targetAlphabet) {
+                    finalAlphabet[fI++] = b;
+                }
+            }
+
+            // Get all characters not in uniques - we need to map these too
+            byte[] allBase64Characters = Arrays.copyOf(finalAlphabet, finalAlphabet.length);
+            unpicked = ByteArrayOperations.subtract(allBase64Characters, uniques);
+
+            // Now do the same but for unmapped
+            unmapped = ByteArrayOperations.subtract(allBase64Characters, shuffledUniques);
+
+            throw new UnsupportedOperationException("TODO");
+        } finally {
+            clear(uniques);
+            clear(required);
+            clear(outputCounts);
+            clear(shuffledUniques);
+            clear(unpicked);
+            clear(unmapped);
+            clear(finalAlphabet);
+        }
+    }
+
+    public static class Builder {
+        private int uppercaseCount = 0;
+        private int lowercaseCount = 1;
+        private int numberCount = 1;
+        private int symbolCount = 0;
+        private byte[] mapping;
+
+        public Builder uppercaseCount(int uppercaseCount) {
+            this.uppercaseCount = uppercaseCount;
+            return this;
+        }
+
+        public Builder lowercaseCount(int lowercaseCount) {
+            this.lowercaseCount = lowercaseCount;
+            return this;
+        }
+
+        public Builder numberCount(int numberCount) {
+            this.numberCount = numberCount;
+            return this;
+        }
+
+        public Builder symbolCount(int symbolCount) {
+            this.symbolCount = symbolCount;
+            return this;
+        }
+
+        public OutputEncoding build() {
+            return new OutputEncoding(this);
+        }
+    }
+
+    private enum Type {
+        UPPERCASE(OutputEncoding.UPPERCASE),
+        LOWERCASE(OutputEncoding.LOWERCASE),
+        NUMBER(NUMBERS),
+        SYMBOL(SYMBOLS);
+
+        private final byte[] alphabet;
+
+        Type(byte[] alphabet) {
+            this.alphabet = alphabet;
+        }
+
+        /**
+         * Picks <pre>n</pre> random characters from the alphabet.
+         *
+         * @param n            The number of random characters
+         * @param secureRandom The PRNG
+         * @return <pre>n</pre> random characters from the alphabet
+         */
+        public byte[] randomN(int n, SecureRandom secureRandom) {
+            byte[] copy = Arrays.copyOf(alphabet, alphabet.length);
+            byte[] output = new byte[n];
+            // Pick, without replacement, n characters
+            // Pick a character at random and then swap with the end.  Then pick from reduced set
+            for (int i = 0; i < n; i++) {
+                final int maskedLength = copy.length - i;
+                final int index = secureRandom.nextInt(maskedLength);
+                output[i] = copy[index];
+
+                byte temp = copy[maskedLength - 1];
+                copy[maskedLength - 1] = copy[index];
+                copy[index] = temp;
+            }
+
+            return output;
+        }
+    }
+}

--- a/src/main/java/org/x42bn6/nopassword/PRNG.java
+++ b/src/main/java/org/x42bn6/nopassword/PRNG.java
@@ -1,0 +1,19 @@
+package org.x42bn6.nopassword;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+/**
+ * {@code PRNG} is a utility class that generates a SHA1PRNG {@link SecureRandom} instance for convenience.
+ */
+public final class PRNG {
+    public static final String ALGORITHM = "SHA1PRNG";
+
+    public static SecureRandom newInstance() {
+        try {
+            return SecureRandom.getInstance(ALGORITHM);
+        } catch (NoSuchAlgorithmException e) {
+            throw new NoPasswordException("Unable to find PRNG with name [" + ALGORITHM + "]", e);
+        }
+    }
+}

--- a/src/main/java/org/x42bn6/nopassword/Salts.java
+++ b/src/main/java/org/x42bn6/nopassword/Salts.java
@@ -73,7 +73,7 @@ public class Salts {
                     "]; cannot bind a new one");
         }
 
-        CredentialMetadata credentialMetadata = new CredentialMetadata(salt, service.getHashingStrategy());
+        CredentialMetadata credentialMetadata = new CredentialMetadata(salt, service);
         // Don't use singletonList for serialization (may want to add more later)
         Collection<CredentialMetadata> value = new ArrayList<>();
         value.add(credentialMetadata);

--- a/src/main/java/org/x42bn6/nopassword/hashingstrategies/Argon2HashingStrategy.java
+++ b/src/main/java/org/x42bn6/nopassword/hashingstrategies/Argon2HashingStrategy.java
@@ -3,9 +3,8 @@ package org.x42bn6.nopassword.hashingstrategies;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.bouncycastle.crypto.params.Argon2Parameters;
-import org.x42bn6.nopassword.NoPasswordException;
+import org.x42bn6.nopassword.PRNG;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
@@ -26,16 +25,7 @@ import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
  */
 @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE)
 public class Argon2HashingStrategy implements HashingStrategy {
-    private static final SecureRandom SECURE_RANDOM;
-
-    static {
-        final String algorithm = "SHA1PRNG";
-        try {
-            SECURE_RANDOM = SecureRandom.getInstance(algorithm);
-        } catch (NoSuchAlgorithmException e) {
-            throw new NoPasswordException("Unable to find PRNG with name [" + algorithm + "]", e);
-        }
-    }
+    private static final SecureRandom SECURE_RANDOM = PRNG.newInstance();
 
     private final int type;
     private final int memoryCost;

--- a/src/main/java/org/x42bn6/nopassword/hashingstrategies/AutomaticArgon2HashingStrategy.java
+++ b/src/main/java/org/x42bn6/nopassword/hashingstrategies/AutomaticArgon2HashingStrategy.java
@@ -1,8 +1,7 @@
 package org.x42bn6.nopassword.hashingstrategies;
 
-import org.x42bn6.nopassword.NoPasswordException;
+import org.x42bn6.nopassword.PRNG;
 
-import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 
 /**
@@ -30,20 +29,11 @@ import java.security.SecureRandom;
  * </dl>
  */
 public class AutomaticArgon2HashingStrategy {
-    private static final SecureRandom SECURE_RANDOM;
+    private static final SecureRandom SECURE_RANDOM = PRNG.newInstance();
     private static final int ITERATIONS_FOR_AVERAGING = 10;
     private static final int SALT_LENGTH = 16;
     private static final int HASH_LENGTH = 32;
     public static final int ONE_SECOND_IN_MILLISECONDS = 1000;
-
-    static {
-        final String algorithm = "SHA1PRNG";
-        try {
-            SECURE_RANDOM = SecureRandom.getInstance(algorithm);
-        } catch (NoSuchAlgorithmException e) {
-            throw new NoPasswordException("Unable to find PRNG with name [" + algorithm + "]", e);
-        }
-    }
 
     /**
      * Determines the optimal strategy through hardware heuristics.

--- a/src/main/java/org/x42bn6/nopassword/utilities/ByteArrayOperations.java
+++ b/src/main/java/org/x42bn6/nopassword/utilities/ByteArrayOperations.java
@@ -1,0 +1,108 @@
+package org.x42bn6.nopassword.utilities;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * {@code ByteArrayOperations} is a utilities class for byte arrays, aimed to be used to manipulate password or
+ * sensitive data.
+ * <p>
+ * If an array is returned, callees should zero-out this value (and its input parameters, as a best-practice) in a
+ * {@code finally} block.
+ */
+public final class ByteArrayOperations {
+    /**
+     * Performs a Fisher-Yates shuffle on an array, randomizing it.  Mutates {@code arr}.
+     *
+     * @param arr  The array to be randomized.  Mutated
+     * @param prng The PRNG.  Recommendation is to use an instance of {@code SecureRandom}.
+     */
+    public static byte[] fisherYatesShuffle(byte[] arr, Random prng) {
+        byte[] result = Arrays.copyOf(arr, arr.length);
+        for (int i = result.length - 1; i > 0; i--) {
+            final int j = prng.nextInt(i);
+            byte temp = result[i];
+            result[i] = result[j];
+            result[j] = temp;
+        }
+
+        return result;
+    }
+
+    /**
+     * Returns true if {@code thisByte} is in {@code arr}; false otherwise.
+     *
+     * @param thisByte The byte to be checked
+     * @param arr      The array
+     * @return true if {@code thisByte} is in {@code arr}; false otherwise
+     */
+    public static boolean checkIn(byte thisByte, byte[] arr) {
+        for (byte thatByte : arr) {
+            if (thatByte == thisByte) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Subtracts {@code subset} from the {@code superset}.  If a byte exists in {@code subset} but not {@code superset},
+     * it is ignored.
+     * <p>
+     * The resulting order should not be assumed.
+     *
+     * @param superset The superset of bytes
+     * @param subset   The subset of bytes
+     */
+    public static byte[] subtract(byte[] superset, byte[] subset) {
+        int intersectionCount = 0;
+
+        // There is no way to do this in one loop without temporarily allocating a byte[] temp variable which should
+        // be avoided if it contains sensitive data (we don't know how long the array will be).
+        // Instead, run two loops - one to find the intersection count (to derive array length) and one to
+        // actually populate it.
+        for (byte b : subset) {
+            if (checkIn(b, superset)) {
+                ++intersectionCount;
+            }
+        }
+
+        byte[] result = new byte[superset.length - intersectionCount];
+        int rI = 0;
+        for (byte b : superset) {
+            if (!checkIn(b, subset)) {
+                result[rI++] = b;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Clears an array of bytes, filling it with 0.
+     *
+     * @param arr The array to fill
+     */
+    public static void clear(byte[] arr) {
+        Arrays.fill(arr, (byte) 0);
+    }
+
+    /**
+     * Clears an array of integers, filling it with 0.
+     *
+     * @param arr The array to fill
+     */
+    public static void clear(int[] arr) {
+        Arrays.fill(arr, 0);
+    }
+
+    /**
+     * Clears an array of boolean values, filling it with false.
+     *
+     * @param arr The array to fill
+     */
+    public static void clear(boolean[] arr) {
+        Arrays.fill(arr, false);
+    }
+}

--- a/src/test/java/org/x42bn6/nopassword/OutputEncodingTest.java
+++ b/src/test/java/org/x42bn6/nopassword/OutputEncodingTest.java
@@ -1,0 +1,79 @@
+package org.x42bn6.nopassword;
+
+import org.junit.Ignore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.EnableJUnit4MigrationSupport;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@EnableJUnit4MigrationSupport
+class OutputEncodingTest {
+    private static final byte[] UPPERCASE = {
+            (byte) 'A', (byte) 'B', (byte) 'C', (byte) 'D', (byte) 'E', (byte) 'F', (byte) 'G',
+            (byte) 'H', (byte) 'I', (byte) 'J', (byte) 'K', (byte) 'L', (byte) 'M', (byte) 'N',
+            (byte) 'O', (byte) 'P', (byte) 'Q', (byte) 'R', (byte) 'S', (byte) 'T', (byte) 'U',
+            (byte) 'V', (byte) 'W', (byte) 'X', (byte) 'Y', (byte) 'Z'
+    };
+
+    private static final byte[] LOWERCASE = {
+            (byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e', (byte) 'f', (byte) 'g',
+            (byte) 'h', (byte) 'i', (byte) 'j', (byte) 'k', (byte) 'l', (byte) 'm', (byte) 'n',
+            (byte) 'o', (byte) 'p', (byte) 'q', (byte) 'r', (byte) 's', (byte) 't', (byte) 'u',
+            (byte) 'v', (byte) 'w', (byte) 'x', (byte) 'y', (byte) 'z'
+    };
+
+    private static final byte[] NUMBERS = {
+            (byte) '0', (byte) '1', (byte) '2', (byte) '3', (byte) '4', (byte) '5', (byte) '6',
+            (byte) '7', (byte) '8', (byte) '9'
+    };
+
+    private static final byte[] SYMBOLS = {
+            (byte) '!', (byte) '"', (byte) '#', (byte) '$', (byte) '%', (byte) '&', (byte) '\'',
+            (byte) '(', (byte) ')', (byte) '*', (byte) '+', (byte) ',', (byte) '-', (byte) '.',
+            (byte) '/'
+    };
+
+    @Ignore
+    @Test
+    void remap_All() {
+        OutputEncoding outputEncoding = new OutputEncoding.Builder()
+                .uppercaseCount(1)
+                .lowercaseCount(1)
+                .numberCount(1)
+                .symbolCount(1)
+                .build();
+
+        final byte[] remap = outputEncoding.remap("password".getBytes(StandardCharsets.UTF_8));
+
+        assertTrue(checkAtLeastN(remap, UPPERCASE, outputEncoding.getUppercaseCount()));
+        assertTrue(checkAtLeastN(remap, LOWERCASE, outputEncoding.getLowercaseCount()));
+        assertTrue(checkAtLeastN(remap, NUMBERS, outputEncoding.getNumberCount()));
+        assertTrue(checkAtLeastN(remap, SYMBOLS, outputEncoding.getSymbolCount()));
+    }
+
+    private boolean checkAtLeastN(byte[] remap, byte[] alphabet, int count) {
+        // Intersect remap and alphabet and get uniques
+        Set<Byte> uniques = new HashSet<>();
+        for (byte b : remap) {
+            if (checkIn(b, alphabet)) {
+                uniques.add(b);
+            }
+        }
+
+        return uniques.size() >= count;
+    }
+
+    private boolean checkIn(byte thisByte, byte[] alphabet) {
+        for (byte thatByte : alphabet) {
+            if (thatByte == thisByte) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/org/x42bn6/nopassword/utilities/ByteArrayOperationsTest.java
+++ b/src/test/java/org/x42bn6/nopassword/utilities/ByteArrayOperationsTest.java
@@ -1,0 +1,72 @@
+package org.x42bn6.nopassword.utilities;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ByteArrayOperationsTest {
+
+    @Test
+    void fisherYatesShuffle() {
+        byte[] input = new byte[]{(byte) 'a', (byte) 'b', (byte) 'c'};
+
+        final Random prng = mock(Random.class);
+        // Swap c with a
+        when(prng.nextInt(2)).thenReturn(0);
+        // Swap b with itself
+        when(prng.nextInt(1)).thenReturn(1);
+
+        byte[] result = ByteArrayOperations.fisherYatesShuffle(input, prng);
+
+        assertArrayEquals(new byte[]{(byte) 'c', (byte) 'b', (byte) 'a'}, result);
+    }
+
+    @Test
+    void checkIn() {
+        byte[] input = new byte[]{(byte) 'a', (byte) 'b', (byte) 'c'};
+
+        assertTrue(ByteArrayOperations.checkIn((byte) 'b', input));
+        assertFalse(ByteArrayOperations.checkIn((byte) 'd', input));
+    }
+
+    @Test
+    void subtract() {
+        byte[] superset = new byte[]{(byte) 'a', (byte) 'b', (byte) 'c', (byte) 'd', (byte) 'e'            };
+        byte[] subset   = new byte[]{(byte) 'a',             (byte) 'c',                         (byte) 'f'};
+
+        byte[] result = ByteArrayOperations.subtract(superset, subset);
+
+        assertArrayEquals(new byte[]{(byte) 'b', (byte) 'd', (byte) 'e'}, result);
+    }
+
+    @Test
+    void clear_Byte() {
+        byte[] input = new byte[]{(byte) 'a', (byte) 'b', (byte) 'c'};
+
+        ByteArrayOperations.clear(input);
+
+        assertArrayEquals(new byte[]{(byte) 0, (byte) 0, (byte) 0}, input);
+    }
+
+    @Test
+    void clear_Int() {
+        int[] input = new int[]{0, 1, 2};
+
+        ByteArrayOperations.clear(input);
+
+        assertArrayEquals(new int[]{0, 0, 0}, input);
+    }
+
+    @Test
+    void clear_Bool() {
+        boolean[] input = new boolean[]{true, false, true, false};
+
+        ByteArrayOperations.clear(input);
+
+        assertArrayEquals(new boolean[]{false, false, false, false}, input);
+    }
+}

--- a/src/test/module/module-info.java
+++ b/src/test/module/module-info.java
@@ -1,6 +1,7 @@
 open module org.x42bn6.nopassword {
     requires org.junit.jupiter.api;
     requires org.mockito;
+    requires org.junit.jupiter.migrationsupport;
 
     exports org.x42bn6.nopassword;
 }


### PR DESCRIPTION
Add initial stub of generating the bijection of mappings to allow for on-off usage of symbols and uppercase as required in per-service passwords (referred to as "alphabet" internally).